### PR TITLE
subscription trx detail should be array

### DIFF
--- a/recurring_response.go
+++ b/recurring_response.go
@@ -20,7 +20,7 @@ type RecrDetailResp struct {
 	Schedule           RecrSchdDetailResp `json:"schedule"`
 	MissedChargeAction string             `json:"missed_charge_action"`
 	TotalRecurrence    int                `json:"total_recurrence"`
-	Transactions       RecrTrxResp        `json:"transactions"`
+	Transactions       []RecrTrxResp      `json:"transactions"`
 	Message            string             `json:"message"`
 }
 


### PR DESCRIPTION
## What does this PR do?
update subscription trx detail should be array

## Why are we doing this? Any context or related work?
https://kitabisa.atlassian.net/browse/ARS-242
