### PR TITLE
change recurring trx signature key rule

### DIFF
--- a/recurring.go
+++ b/recurring.go
@@ -115,5 +115,5 @@ func (r *recurringGateway) Finish(registerID string) (resp RecrResp, err error) 
 
 // ValidateSignKey validate signature key on callback request
 func (r *recurringGateway) ValidateSignKey(req RecrCallbackReq) bool {
-	return validateSignatureKey(r.client.XSignKey, req.RegisterID, req.SignatureKey)
+	return validateSignatureKeyRecurringTransaction(r.client.XSignKey, req.RegisterID, req.SignatureKey, req.Amount)
 }

--- a/util.go
+++ b/util.go
@@ -27,3 +27,10 @@ func validateSignatureKey(xSignKey, registerID, SignatureKey string) bool {
 
 	return fmt.Sprintf("%x", hashToValidate) == SignatureKey
 }
+
+func validateSignatureKeyRecurringTransaction(xSignKey, registerID, SignatureKey string, amount float64) bool {
+	dataToHash := []byte(fmt.Sprint(xSignKey, registerID, amount))
+	hashToValidate := sha256.Sum256(dataToHash)
+
+	return fmt.Sprintf("%x", hashToValidate) == SignatureKey
+}


### PR DESCRIPTION
## What does this PR do?
change recurring trx signature key rule accoring to vendor, to add amount in signature key

`sha256(x-sign-key + registerid + amount)`

## Why are we doing this? Any context or related work?
https://kitabisa.atlassian.net/browse/ARS-241
